### PR TITLE
add include_orders=true to API params

### DIFF
--- a/src/helpers/openseaUtils.ts
+++ b/src/helpers/openseaUtils.ts
@@ -2,7 +2,7 @@ const OPENSEA_BASE_URI = 'https://api.opensea.io/wyvern/v1';
 
 export const getOSAssetOrder = async ({tokenAddress, tokenId, orderSide}) => {
   const orders = await fetch(
-    `${OPENSEA_BASE_URI}/orders/?asset_contract_address=${tokenAddress}&limit=1&side=${orderSide}&token_id=${tokenId}&include_orders=true`,
+    `${OPENSEA_BASE_URI}/orders/?asset_contract_address=${tokenAddress}&limit=1&side=${orderSide}&token_id=${tokenId}`,
     {
       method: 'GET',
       headers: {

--- a/src/helpers/openseaUtils.ts
+++ b/src/helpers/openseaUtils.ts
@@ -2,7 +2,7 @@ const OPENSEA_BASE_URI = 'https://api.opensea.io/wyvern/v1';
 
 export const getOSAssetOrder = async ({tokenAddress, tokenId, orderSide}) => {
   const orders = await fetch(
-    `${OPENSEA_BASE_URI}/orders/?asset_contract_address=${tokenAddress}&limit=1&side=${orderSide}&token_id=${tokenId}`,
+    `${OPENSEA_BASE_URI}/orders/?asset_contract_address=${tokenAddress}&limit=1&side=${orderSide}&token_id=${tokenId}&include_orders=true`,
     {
       method: 'GET',
       headers: {

--- a/src/pages/gallery.tsx
+++ b/src/pages/gallery.tsx
@@ -35,6 +35,7 @@ export async function getServerSideProps() {
     estimatedCount: number;
   } = await seaport.api.getAssets({
     collection_slug: process.env.OPEN_SEA_COLLECTION_SLUG,
+    include_orders: true,
   } as any);
 
   const assets = JSON.parse(JSON.stringify(response)).assets;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,6 +31,7 @@ export async function getServerSideProps() {
     await seaport.api
       .getAssets({
         collection_slug: process.env.OPEN_SEA_COLLECTION_SLUG,
+        include_orders: true,
       } as any)
       .then((apiResponse: {assets: OpenSeaAsset[]; estimatedCount: number}) => {
         console.log(apiResponse);


### PR DESCRIPTION
need to add this because of Opensea API change March 8th.

see https://docs.opensea.io/changelog/updated-timeline-for-march-1-api-migrations for more info